### PR TITLE
added overflow hidden for right_labels

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,6 +38,7 @@ td {
 }
 .right_labels {
 	float: right;
+    overflow: hidden;
 }
 #internal-links {
 	display: none;


### PR DESCRIPTION
Problem: When put mouse over a color icon of label whose line has more than two labels, I found sometimes we get wrong tool-tip. Mostly we get tool-tip of the left most label for all color icons.

It seems there is hidden string behind each color icon which could overflow to right side of the color icon, and such string will make wrong tool-tip.
This change adds overflow: hidden to color icons, which prevents such hidden strings.