### PR TITLE
Fix repository concatenation

### DIFF
--- a/set-labels.js
+++ b/set-labels.js
@@ -238,7 +238,7 @@ async function run() {
 
   let repositories = await tracked_repositories.w3c();
 
-  repositories.concat(await tracked_repositories.extra());
+  repositories = repositories.concat(await tracked_repositories.extra());
 
   // add a few more repositories, such as the repository template
   repositories = repositories.concat(["w3c/note-respec-repo-template"]);


### PR DESCRIPTION
`concat` does not modify the original array, so the value is discarded.